### PR TITLE
Implement reconciliation service foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ninja-payments-reconciler"
+version = "0.1.0"
+description = "Standalone reconciliation service for PSP polling and CRM integration"
+authors = [{name = "Ninja"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.109.0",
+    "uvicorn[standard]>=0.27.0",
+    "pydantic>=2.5.0",
+    "pydantic-settings>=2.0.0",
+    "psycopg2-binary>=2.9.0",
+    "httpx>=0.25.0",
+    "python-dateutil>=2.8.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.20.0",
+    "ruff>=0.1.0"
+]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B", "UP", "N", "C4", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.isort]
+known-first-party = ["src"]
+profile = "black"

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Dict
+
+from fastapi import FastAPI
+
+from .db import create_database
+from .integrations.crm_client import CRMClient
+from .integrations.providers import paypal, stripe, webpay
+from .integrations.providers.base import ProviderClient
+from .loops.crm_sender import CrmSender
+from .loops.psp_poller import PspPoller
+from .repositories import payments_repo
+from .settings import get_settings
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_app() -> FastAPI:
+    logging.basicConfig(level=logging.INFO)
+    settings = get_settings()
+
+    provider_clients: Dict[str, ProviderClient] = {
+        "webpay": webpay.create(),
+        "stripe": stripe.create(),
+        "paypal": paypal.create(),
+    }
+
+    providers = {
+        name: client
+        for name, client in provider_clients.items()
+        if name in settings.reconcile_polling_providers
+    }
+
+    crm_client = CRMClient(
+        base_url=settings.crm_base_url,
+        pagar_path=settings.crm_pagar_path,
+        bearer_token=settings.crm_auth_bearer,
+        timeout_seconds=settings.crm_timeout_seconds,
+        log_requests=settings.crm_log_requests,
+    )
+
+    app = FastAPI(title=settings.app_name)
+
+    app.state.settings = settings
+    app.state.providers = providers
+    app.state.crm_client = crm_client
+    app.state.database = None
+    app.state.poller: PspPoller | None = None
+    app.state.sender: CrmSender | None = None
+    app.state.background_tasks: list[asyncio.Task] = []
+
+    @app.on_event("startup")
+    async def on_startup() -> None:
+        LOGGER.info("Starting service")
+        database = create_database()
+        app.state.database = database
+        poller = PspPoller(db=database, settings=settings, providers=providers)
+        sender = CrmSender(db=database, settings=settings, client=crm_client)
+        app.state.poller = poller
+        app.state.sender = sender
+        with database.connection() as conn:
+            payments_repo.log_service_runtime_event(
+                conn,
+                event_type="STARTUP",
+                payload={"app": settings.app_name},
+            )
+        app.state.background_tasks.append(asyncio.create_task(poller.run(), name="psp_poller"))
+        app.state.background_tasks.append(asyncio.create_task(sender.run(), name="crm_sender"))
+
+    @app.on_event("shutdown")
+    async def on_shutdown() -> None:
+        LOGGER.info("Shutting down service")
+        for task in app.state.background_tasks:
+            task.cancel()
+        for task in app.state.background_tasks:
+            with suppress(asyncio.CancelledError):
+                await task
+        database = app.state.database
+        if database is not None:
+            with database.connection() as conn:
+                payments_repo.log_service_runtime_event(
+                    conn,
+                    event_type="SHUTDOWN",
+                    payload={"app": settings.app_name},
+                )
+            database.close()
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+app = create_app()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import Iterator
+
+import psycopg2
+from psycopg2.pool import ThreadedConnectionPool
+
+from .settings import get_settings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Database:
+    def __init__(self, dsn: str, minconn: int = 1, maxconn: int = 10) -> None:
+        self._dsn = dsn
+        self._pool = ThreadedConnectionPool(minconn=minconn, maxconn=maxconn, dsn=dsn)
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET search_path TO payments")
+                conn.commit()
+
+    @contextlib.contextmanager
+    def connection(self) -> Iterator[psycopg2.extensions.connection]:
+        conn = self._pool.getconn()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("SET search_path TO payments")
+                yield conn
+        finally:
+            self._pool.putconn(conn)
+
+    def close(self) -> None:
+        LOGGER.info("Closing database pool")
+        self._pool.closeall()
+
+
+def create_database() -> Database:
+    settings = get_settings()
+    return Database(settings.database_dsn)

--- a/src/integrations/crm_client.py
+++ b/src/integrations/crm_client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import httpx
+
+from .providers.base import mask_sensitive_headers
+
+
+@dataclass(slots=True)
+class CrmResponse:
+    status_code: int
+    headers: Dict[str, Any]
+    body: Dict[str, Any] | None
+    crm_id: str | None
+    latency_ms: int
+
+
+class CRMClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        pagar_path: str,
+        bearer_token: str | None,
+        timeout_seconds: int,
+        log_requests: bool = True,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.pagar_path = pagar_path
+        self.bearer_token = bearer_token
+        self.timeout_seconds = timeout_seconds
+        self.log_requests = log_requests
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.base_url}{self.pagar_path}"
+
+    def send(
+        self, payload: Dict[str, Any]
+    ) -> tuple[CrmResponse, Dict[str, Any], Dict[str, Any], Dict[str, Any], Dict[str, Any], str | None]:
+        url = self.endpoint
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if self.bearer_token:
+            headers["Authorization"] = f"Bearer {self.bearer_token}"
+
+        start = time.monotonic()
+        response_headers: Dict[str, Any] | None = None
+        response_body: Dict[str, Any] | None = None
+        status_code: int = 0
+        crm_id: str | None = None
+        error_message: str | None = None
+        try:
+            with httpx.Client(timeout=self.timeout_seconds) as client:
+                response = client.post(url, headers=headers, json=payload)
+            status_code = response.status_code
+            response_headers = dict(response.headers)
+            if response.headers.get("content-type", "").startswith("application/json"):
+                response_body = response.json()
+            else:
+                response_body = {"raw": response.text}
+            if isinstance(response_body, dict):
+                crm_id = response_body.get("id")
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            error_message = str(exc)
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        if response_body is not None:
+            response_payload = response_body
+        elif error_message is not None:
+            response_payload = {"error": error_message}
+        else:
+            response_payload = {"status_code": status_code}
+        crm_response = CrmResponse(
+            status_code=status_code,
+            headers=response_headers or {},
+            body=response_payload,
+            crm_id=crm_id,
+            latency_ms=latency_ms,
+        )
+        masked_request_headers = mask_sensitive_headers(headers)
+        masked_response_headers = mask_sensitive_headers(response_headers or {})
+        return (
+            crm_response,
+            masked_request_headers,
+            payload,
+            masked_response_headers,
+            response_payload,
+            error_message,
+        )

--- a/src/integrations/providers/base.py
+++ b/src/integrations/providers/base.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ProviderStatusResult:
+    provider_status: str | None
+    mapped_status: str | None
+    response_code: int | None
+    payload: Dict[str, Any] | None
+
+
+@dataclass(slots=True)
+class ProviderCallLog:
+    request_url: str
+    request_headers: Dict[str, Any]
+    request_body: Dict[str, Any] | None
+    response_status: int | None
+    response_headers: Dict[str, Any] | None
+    response_body: Dict[str, Any] | None
+    error_message: str | None
+    latency_ms: int | None
+
+
+class ProviderClient(Protocol):
+    name: str
+
+    def status(self, token: str) -> tuple[ProviderStatusResult, ProviderCallLog]:  # pragma: no cover
+        ...
+
+
+def mask_sensitive_headers(headers: dict[str, Any]) -> dict[str, Any]:
+    masked: dict[str, Any] = {}
+    for key, value in headers.items():
+        if key.lower() in {"authorization", "tbk-api-key-secret", "x-api-key"}:
+            masked[key] = "***"
+        else:
+            masked[key] = value
+    return masked

--- a/src/integrations/providers/paypal.py
+++ b/src/integrations/providers/paypal.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import Any, Dict
+
+import httpx
+
+from .base import ProviderCallLog, ProviderClient, ProviderStatusResult, mask_sensitive_headers
+
+
+class PayPalProvider:
+    name = "paypal"
+
+    def __init__(
+        self,
+        *,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self.client_id = client_id or os.getenv("PAYPAL_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("PAYPAL_CLIENT_SECRET")
+        self.base_url = base_url or os.getenv("PAYPAL_BASE_URL", "https://api.paypal.com")
+
+    def status(self, token: str) -> tuple[ProviderStatusResult, ProviderCallLog]:
+        url = f"{self.base_url}/v2/checkout/orders/{token}"
+        headers: Dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+
+        start = time.monotonic()
+        error_message: str | None = None
+        response_status: int | None = None
+        response_headers: Dict[str, Any] | None = None
+        response_body: Dict[str, Any] | None = None
+
+        auth_header: Dict[str, str] | None = None
+        try:
+            access_token = self._fetch_access_token()
+            if access_token:
+                headers["Authorization"] = f"Bearer {access_token}"
+                auth_header = {"Authorization": headers["Authorization"]}
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            error_message = f"token_error: {exc}"  # type: ignore[str-format]
+        except ValueError as exc:
+            error_message = str(exc)
+
+        if error_message is None:
+            try:
+                with httpx.Client(timeout=10) as client:
+                    resp = client.get(url, headers=headers)
+                response_status = resp.status_code
+                response_headers = dict(resp.headers)
+                if resp.headers.get("content-type", "").startswith("application/json"):
+                    response_body = resp.json()
+                else:
+                    response_body = {"raw": resp.text}
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                error_message = str(exc)
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+
+        provider_status = None
+        mapped_status = None
+        if response_body and isinstance(response_body, dict):
+            provider_status = response_body.get("status")
+            mapped_status = self._map_status(provider_status)
+
+        result = ProviderStatusResult(
+            provider_status=provider_status,
+            mapped_status=mapped_status,
+            response_code=response_status,
+            payload=response_body,
+        )
+        merged_headers = {**headers}
+        if auth_header:
+            merged_headers.update(auth_header)
+        log = ProviderCallLog(
+            request_url=url,
+            request_headers=mask_sensitive_headers(merged_headers),
+            request_body=None,
+            response_status=response_status,
+            response_headers=mask_sensitive_headers(response_headers or {}),
+            response_body=response_body,
+            error_message=error_message,
+            latency_ms=latency_ms,
+        )
+        return result, log
+
+    def _fetch_access_token(self) -> str:
+        if not self.client_id or not self.client_secret:
+            raise ValueError("PayPal credentials are not configured")
+        token_url = f"{self.base_url}/v1/oauth2/token"
+        credentials = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
+        headers = {
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        with httpx.Client(timeout=10) as client:
+            response = client.post(token_url, headers=headers, data={"grant_type": "client_credentials"})
+        response.raise_for_status()
+        data = response.json()
+        return data["access_token"]
+
+    @staticmethod
+    def _map_status(provider_status: str | None) -> str | None:
+        if provider_status is None:
+            return None
+        mapping = {
+            "COMPLETED": "AUTHORIZED",
+            "APPROVED": "TO_CONFIRM",
+            "CREATED": "PENDING",
+            "VOIDED": "CANCELED",
+            "PAYER_ACTION_REQUIRED": "TO_CONFIRM",
+        }
+        return mapping.get(provider_status.upper(), None)
+
+
+def create() -> ProviderClient:
+    return PayPalProvider()

--- a/src/integrations/providers/stripe.py
+++ b/src/integrations/providers/stripe.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import Any, Dict
+
+import httpx
+
+from .base import ProviderCallLog, ProviderClient, ProviderStatusResult, mask_sensitive_headers
+
+
+class StripeProvider:
+    name = "stripe"
+
+    def __init__(self, *, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("STRIPE_API_KEY")
+        self.base_url = os.getenv("STRIPE_API_BASE", "https://api.stripe.com")
+
+    def status(self, token: str) -> tuple[ProviderStatusResult, ProviderCallLog]:
+        url = f"{self.base_url}/v1/payment_intents/{token}"
+        headers: Dict[str, str] = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        if not self.api_key:
+            error = "Stripe API key is not configured"
+            result = ProviderStatusResult(None, None, None, None)
+            log = ProviderCallLog(
+                request_url=url,
+                request_headers=headers,
+                request_body=None,
+                response_status=None,
+                response_headers=None,
+                response_body=None,
+                error_message=error,
+                latency_ms=0,
+            )
+            return result, log
+
+        start = time.monotonic()
+        error_message: str | None = None
+        response_status: int | None = None
+        response_headers: Dict[str, Any] | None = None
+        response_body: Dict[str, Any] | None = None
+        try:
+            with httpx.Client(timeout=10) as client:
+                resp = client.get(url, auth=(self.api_key, ""), headers=headers)
+            response_status = resp.status_code
+            response_headers = dict(resp.headers)
+            response_body = resp.json()
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            error_message = str(exc)
+            resp = None  # type: ignore[assignment]
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+
+        provider_status = None
+        mapped_status = None
+        if response_body:
+            provider_status = response_body.get("status")
+            mapped_status = self._map_status(provider_status)
+
+        result = ProviderStatusResult(
+            provider_status=provider_status,
+            mapped_status=mapped_status,
+            response_code=response_status,
+            payload=response_body,
+        )
+        log = ProviderCallLog(
+            request_url=url,
+            request_headers=mask_sensitive_headers({**headers, "Authorization": f"Basic {base64.b64encode(f'{self.api_key}:'.encode()).decode()}"})
+            if self.api_key
+            else headers,
+            request_body=None,
+            response_status=response_status,
+            response_headers=mask_sensitive_headers(response_headers or {}),
+            response_body=response_body,
+            error_message=error_message,
+            latency_ms=latency_ms,
+        )
+        return result, log
+
+    @staticmethod
+    def _map_status(provider_status: str | None) -> str | None:
+        if provider_status is None:
+            return None
+        mapping = {
+            "succeeded": "AUTHORIZED",
+            "processing": "TO_CONFIRM",
+            "requires_payment_method": "FAILED",
+            "requires_action": "TO_CONFIRM",
+            "requires_capture": "AUTHORIZED",
+            "canceled": "CANCELED",
+        }
+        return mapping.get(provider_status.lower(), None)
+
+
+def create() -> ProviderClient:
+    return StripeProvider()

--- a/src/integrations/providers/webpay.py
+++ b/src/integrations/providers/webpay.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict
+
+import httpx
+
+from .base import ProviderCallLog, ProviderClient, ProviderStatusResult, mask_sensitive_headers
+
+
+class WebpayProvider:
+    name = "webpay"
+
+    def __init__(
+        self,
+        *,
+        status_url_template: str | None = None,
+        api_key_id: str | None = None,
+        api_key_secret: str | None = None,
+    ) -> None:
+        self.status_url_template = status_url_template or os.getenv(
+            "WEBPAY_STATUS_URL_TEMPLATE", "https://webpay.transbank.cl/rest/transactions/{token}"
+        )
+        self.api_key_id = api_key_id or os.getenv("WEBPAY_API_KEY_ID")
+        self.api_key_secret = api_key_secret or os.getenv("WEBPAY_API_KEY_SECRET")
+        self.commerce_code = os.getenv("WEBPAY_COMMERCE_CODE")
+
+    def status(self, token: str) -> tuple[ProviderStatusResult, ProviderCallLog]:
+        url = self.status_url_template.format(token=token)
+        headers: Dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+        if self.api_key_id:
+            headers["Tbk-Api-Key-Id"] = self.api_key_id
+        if self.api_key_secret:
+            headers["Tbk-Api-Key-Secret"] = self.api_key_secret
+        if self.commerce_code:
+            headers["Tbk-Commerce-Code"] = self.commerce_code
+
+        start = time.monotonic()
+        error_message: str | None = None
+        response_status: int | None = None
+        response_headers: Dict[str, Any] | None = None
+        response_body: Dict[str, Any] | None = None
+        try:
+            with httpx.Client(timeout=10) as client:
+                resp = client.get(url, headers=headers)
+            response_status = resp.status_code
+            response_headers = dict(resp.headers)
+            if resp.headers.get("content-type", "").startswith("application/json"):
+                response_body = resp.json()
+            else:
+                response_body = {"raw": resp.text}
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            error_message = str(exc)
+            response_body = None
+            response_headers = None
+            resp = None  # type: ignore[assignment]
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+
+        provider_status = None
+        mapped_status = None
+        if response_body and isinstance(response_body, dict):
+            provider_status = str(response_body.get("status")) if response_body.get("status") else None
+            mapped_status = self._map_status(provider_status)
+
+        result = ProviderStatusResult(
+            provider_status=provider_status,
+            mapped_status=mapped_status,
+            response_code=response_status,
+            payload=response_body,
+        )
+        log = ProviderCallLog(
+            request_url=url,
+            request_headers=mask_sensitive_headers(headers),
+            request_body=None,
+            response_status=response_status,
+            response_headers=mask_sensitive_headers(response_headers or {}),
+            response_body=response_body,
+            error_message=error_message,
+            latency_ms=latency_ms,
+        )
+        return result, log
+
+    @staticmethod
+    def _map_status(provider_status: str | None) -> str | None:
+        mapping = {
+            "AUTHORIZED": "AUTHORIZED",
+            "FAILED": "FAILED",
+            "REJECTED": "FAILED",
+            "REVERSED": "CANCELED",
+            "NULLIFIED": "CANCELED",
+            "PENDING": "PENDING",
+            "INITIALIZED": "PENDING",
+        }
+        if provider_status is None:
+            return None
+        return mapping.get(provider_status.upper(), None)
+
+
+def create() -> ProviderClient:
+    return WebpayProvider()

--- a/src/loops/crm_sender.py
+++ b/src/loops/crm_sender.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from ..db import Database
+from ..integrations.crm_client import CRMClient
+from ..repositories import crm_repo, payments_repo
+from ..settings import Settings
+
+
+class CrmSender:
+    def __init__(
+        self,
+        *,
+        db: Database,
+        settings: Settings,
+        client: CRMClient,
+    ) -> None:
+        self._db = db
+        self._settings = settings
+        self._client = client
+        self._heartbeat_at: datetime | None = None
+
+    async def run(self) -> None:
+        while True:
+            if not self._settings.crm_enabled:
+                await asyncio.sleep(self._settings.reconcile_interval_seconds)
+                continue
+            await asyncio.to_thread(self._process_once)
+            await asyncio.sleep(self._settings.reconcile_interval_seconds)
+
+    def _process_once(self) -> None:
+        stats = {"sent": 0, "failed": 0, "retried": 0}
+        with self._db.connection() as conn:
+            reactivated = crm_repo.reactivate_failed_items(
+                conn, limit=self._settings.reconcile_batch_size
+            )
+            if reactivated:
+                stats["retried"] += reactivated
+            queue_items = crm_repo.fetch_pending_crm_items(
+                conn, limit=self._settings.reconcile_batch_size
+            )
+            now = datetime.now(timezone.utc)
+            for item in queue_items:
+                response, req_headers, req_body, resp_headers, resp_body, error_message = self._client.send(
+                    item.payload
+                )
+                crm_repo.record_crm_event(
+                    conn,
+                    payment_id=item.payment_id,
+                    operation=item.operation,
+                    request_url=self._client.endpoint,
+                    request_headers=req_headers,
+                    request_body=req_body,
+                    response_status=response.status_code,
+                    response_headers=resp_headers,
+                    response_body=resp_body,
+                    error_message=error_message,
+                    latency_ms=response.latency_ms,
+                )
+
+                if 200 <= response.status_code < 300 and error_message is None:
+                    crm_repo.update_crm_item_success(
+                        conn,
+                        item_id=item.id,
+                        response_code=response.status_code,
+                        crm_id=response.crm_id,
+                    )
+                    stats["sent"] += 1
+                else:
+                    attempts = item.attempts + 1
+                    backoff_index = min(attempts - 1, len(self._settings.crm_retry_backoff) - 1)
+                    next_attempt = now + timedelta(
+                        seconds=self._settings.crm_retry_backoff[backoff_index]
+                    )
+                    crm_repo.update_crm_item_failure(
+                        conn,
+                        item_id=item.id,
+                        attempts=attempts,
+                        next_attempt_at=next_attempt,
+                        response_code=response.status_code if response.status_code else None,
+                        error_message=error_message or "CRM send failed",
+                    )
+                    stats["failed"] += 1
+            self._emit_runtime_log(conn, stats)
+
+    def _emit_runtime_log(self, conn, stats: Dict[str, int]) -> None:
+        now = datetime.now(timezone.utc)
+        if self._heartbeat_at and now < self._heartbeat_at:
+            return
+        self._heartbeat_at = now + timedelta(seconds=self._settings.heartbeat_interval_seconds)
+        payments_repo.log_service_runtime_event(
+            conn,
+            event_type="HEARTBEAT",
+            payload={"crm_sender": stats},
+        )

--- a/src/loops/psp_poller.py
+++ b/src/loops/psp_poller.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from ..db import Database
+from ..integrations.providers.base import ProviderClient
+from ..repositories import crm_repo, payments_repo
+from ..services.crm_payloads import build_payload
+from ..settings import Settings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PspPoller:
+    def __init__(
+        self,
+        *,
+        db: Database,
+        settings: Settings,
+        providers: Dict[str, ProviderClient],
+    ) -> None:
+        self._db = db
+        self._settings = settings
+        self._providers = providers
+        self._heartbeat_at: datetime | None = None
+
+    async def run(self) -> None:
+        while True:
+            if not self._settings.reconcile_enabled:
+                await asyncio.sleep(self._settings.reconcile_interval_seconds)
+                continue
+            await asyncio.to_thread(self._process_once)
+            await asyncio.sleep(self._settings.reconcile_interval_seconds)
+
+    def _process_once(self) -> None:
+        stats = {
+            "payments": 0,
+            "updated": 0,
+            "failed": 0,
+            "skipped": 0,
+        }
+        with self._db.connection() as conn:
+            payments = payments_repo.select_payments_for_reconciliation(
+                conn,
+                providers=self._settings.reconcile_polling_providers,
+                batch_size=self._settings.reconcile_batch_size,
+            )
+            now = datetime.now(timezone.utc)
+            for payment in payments:
+                stats["payments"] += 1
+                provider = self._providers.get(payment.provider)
+                if not provider:
+                    LOGGER.warning("No provider client configured for %s", payment.provider)
+                    stats["skipped"] += 1
+                    continue
+
+                attempt_index = payment.attempts
+                if attempt_index >= len(self._settings.reconcile_attempt_offsets):
+                    payments_repo.mark_attempts_exhausted(conn, payment_id=payment.id)
+                    stats["failed"] += 1
+                    continue
+
+                due_at = payment.created_at + timedelta(
+                    seconds=self._settings.reconcile_attempt_offsets[attempt_index]
+                )
+                if now < due_at:
+                    stats["skipped"] += 1
+                    continue
+
+                result, call_log = provider.status(payment.token)
+                payments_repo.record_provider_event(
+                    conn,
+                    payment_id=payment.id,
+                    provider=payment.provider,
+                    request_url=call_log.request_url,
+                    request_headers=call_log.request_headers,
+                    request_body=call_log.request_body,
+                    response_status=call_log.response_status,
+                    response_headers=call_log.response_headers,
+                    response_body=call_log.response_body,
+                    error_message=call_log.error_message,
+                    latency_ms=call_log.latency_ms,
+                )
+
+                success = call_log.error_message is None and result.provider_status is not None
+                payments_repo.record_status_check(
+                    conn,
+                    payment_id=payment.id,
+                    provider=payment.provider,
+                    success=success,
+                    provider_status=result.provider_status,
+                    mapped_status=result.mapped_status,
+                    response_code=result.response_code,
+                    raw_payload=result.payload,
+                    error_message=call_log.error_message,
+                )
+
+                if result.mapped_status is None:
+                    if attempt_index + 1 >= len(self._settings.reconcile_attempt_offsets):
+                        payments_repo.mark_attempts_exhausted(conn, payment_id=payment.id)
+                        stats["failed"] += 1
+                    continue
+
+                if result.mapped_status == payment.status:
+                    continue
+
+                status_reason = payment.status_reason
+                if result.mapped_status in {"AUTHORIZED", "FAILED", "CANCELED", "REFUNDED"}:
+                    status_reason = "provider reconciliation update"
+
+                payments_repo.update_payment_status(
+                    conn,
+                    payment_id=payment.id,
+                    new_status=result.mapped_status,
+                    status_reason=status_reason,
+                )
+                stats["updated"] += 1
+
+                if result.mapped_status == "AUTHORIZED":
+                    payload = build_payload(payment, "PAYMENT_APPROVED")
+                    crm_repo.enqueue_crm_operation(
+                        conn,
+                        payment_id=payment.id,
+                        operation="PAYMENT_APPROVED",
+                        payload=payload,
+                    )
+
+
+            cutoff = now - timedelta(minutes=self._settings.abandoned_timeout_minutes)
+            abandoned_payments = payments_repo.find_abandoned_payments(
+                conn, cutoff=cutoff, limit=self._settings.reconcile_batch_size
+            )
+            for abandoned in abandoned_payments:
+                payments_repo.update_payment_status(
+                    conn,
+                    payment_id=abandoned.id,
+                    new_status="ABANDONED",
+                    status_reason="abandoned timeout",
+                )
+                payload = build_payload(abandoned, "ABANDONED_CART")
+                crm_repo.enqueue_crm_operation(
+                    conn,
+                    payment_id=abandoned.id,
+                    operation="ABANDONED_CART",
+                    payload=payload,
+                )
+                stats.setdefault("abandoned", 0)
+                stats["abandoned"] += 1
+
+            self._emit_runtime_log(conn, stats)
+
+    def _emit_runtime_log(self, conn, stats: Dict[str, int]) -> None:
+        now = datetime.now(timezone.utc)
+        if self._heartbeat_at and now < self._heartbeat_at:
+            return
+        self._heartbeat_at = now + timedelta(seconds=self._settings.heartbeat_interval_seconds)
+        payments_repo.log_service_runtime_event(
+            conn,
+            event_type="HEARTBEAT",
+            payload={"psp_poller": stats},
+        )

--- a/src/repositories/crm_repo.py
+++ b/src/repositories/crm_repo.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+import psycopg2.extras
+
+
+@dataclass(slots=True)
+class CrmQueueItem:
+    id: int
+    payment_id: int
+    operation: str
+    status: str
+    attempts: int
+    next_attempt_at: datetime | None
+    payload: dict
+
+
+def enqueue_crm_operation(
+    conn,
+    *,
+    payment_id: int,
+    operation: str,
+    payload: dict,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO payments.crm_push_queue (
+                payment_id,
+                operation,
+                status,
+                attempts,
+                payload
+            ) VALUES (%s, %s, 'PENDING', 0, %s::jsonb)
+            ON CONFLICT (payment_id, operation)
+            DO UPDATE SET
+                status = 'PENDING',
+                attempts = 0,
+                next_attempt_at = NULL,
+                last_attempt_at = NULL,
+                response_code = NULL,
+                crm_id = NULL,
+                last_error = NULL,
+                payload = EXCLUDED.payload,
+                updated_at = NOW()
+            """,
+            (
+                payment_id,
+                operation,
+                psycopg2.extras.Json(payload),
+            ),
+        )
+
+
+def fetch_pending_crm_items(conn, *, limit: int = 50) -> List[CrmQueueItem]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT
+                id,
+                payment_id,
+                operation,
+                status,
+                attempts,
+                next_attempt_at,
+                payload
+            FROM payments.crm_push_queue
+            WHERE status = 'PENDING'
+              AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+            ORDER BY created_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        rows = cur.fetchall()
+
+    return [
+        CrmQueueItem(
+            id=row["id"],
+            payment_id=row["payment_id"],
+            operation=row["operation"],
+            status=row["status"],
+            attempts=row["attempts"],
+            next_attempt_at=row.get("next_attempt_at"),
+            payload=row.get("payload") or {},
+        )
+        for row in rows
+    ]
+
+
+def update_crm_item_success(
+    conn,
+    *,
+    item_id: int,
+    response_code: int,
+    crm_id: str | None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE payments.crm_push_queue
+            SET status = 'SENT',
+                response_code = %s,
+                crm_id = %s,
+                last_error = NULL,
+                updated_at = NOW()
+            WHERE id = %s
+            """,
+            (response_code, crm_id, item_id),
+        )
+
+
+def update_crm_item_failure(
+    conn,
+    *,
+    item_id: int,
+    attempts: int,
+    next_attempt_at: datetime | None,
+    response_code: int | None,
+    error_message: str,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE payments.crm_push_queue
+            SET status = 'FAILED',
+                attempts = %s,
+                next_attempt_at = %s,
+                last_attempt_at = NOW(),
+                response_code = %s,
+                last_error = %s,
+                updated_at = NOW()
+            WHERE id = %s
+            """,
+            (attempts, next_attempt_at, response_code, error_message, item_id),
+        )
+
+
+def reset_crm_item_for_retry(
+    conn,
+    *,
+    item_id: int,
+    attempts: int,
+    next_attempt_at: datetime | None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE payments.crm_push_queue
+            SET status = 'PENDING',
+                attempts = %s,
+                next_attempt_at = %s,
+                last_attempt_at = NOW(),
+                updated_at = NOW()
+            WHERE id = %s
+            """,
+            (attempts, next_attempt_at, item_id),
+        )
+
+
+def record_crm_event(
+    conn,
+    *,
+    payment_id: int,
+    operation: str,
+    request_url: str,
+    request_headers: dict,
+    request_body: dict | None,
+    response_status: int | None,
+    response_headers: dict | None,
+    response_body: dict | None,
+    error_message: str | None,
+    latency_ms: int | None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO payments.crm_event_log (
+                payment_id,
+                operation,
+                request_url,
+                request_headers,
+                request_body,
+                response_status,
+                response_headers,
+                response_body,
+                error_message,
+                latency_ms
+            ) VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s::jsonb, %s::jsonb, %s, %s)
+            """,
+            (
+                payment_id,
+                operation,
+                request_url,
+                psycopg2.extras.Json(request_headers),
+                psycopg2.extras.Json(request_body) if request_body is not None else None,
+                response_status,
+                psycopg2.extras.Json(response_headers) if response_headers is not None else None,
+                psycopg2.extras.Json(response_body) if response_body is not None else None,
+                error_message,
+                latency_ms,
+            ),
+        )
+
+
+
+def reactivate_failed_items(conn, *, limit: int = 100) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH moved AS (
+                SELECT id
+                FROM payments.crm_push_queue
+                WHERE status = 'FAILED'
+                  AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+                ORDER BY next_attempt_at NULLS FIRST
+                FOR UPDATE SKIP LOCKED
+                LIMIT %s
+            )
+            UPDATE payments.crm_push_queue AS q
+            SET status = 'PENDING'
+            FROM moved
+            WHERE q.id = moved.id
+            RETURNING q.id
+            """,
+            (limit,),
+        )
+        return cur.rowcount

--- a/src/repositories/payments_repo.py
+++ b/src/repositories/payments_repo.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Sequence
+
+import psycopg2.extras
+
+
+@dataclass(slots=True)
+class Payment:
+    id: int
+    status: str
+    provider: str
+    token: str
+    created_at: datetime
+    amount_minor: int
+    provider_metadata: dict | None
+    context: dict | None
+    product_id: int | None
+    authorization_code: str | None
+    status_reason: str | None
+    attempts: int
+
+
+def select_payments_for_reconciliation(
+    conn,
+    *,
+    providers: Sequence[str],
+    batch_size: int,
+) -> List[Payment]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT
+                p.id,
+                p.status,
+                p.provider,
+                p.token,
+                p.created_at,
+                p.amount_minor,
+                p.provider_metadata,
+                p.context,
+                p.product_id,
+                p.authorization_code,
+                p.status_reason,
+                COALESCE(sc.attempts, 0) AS attempts
+            FROM payments.payment AS p
+            LEFT JOIN (
+                SELECT payment_id, COUNT(*) AS attempts
+                FROM payments.status_check
+                GROUP BY payment_id
+            ) AS sc ON sc.payment_id = p.id
+            WHERE p.status IN ('PENDING', 'TO_CONFIRM')
+              AND p.token IS NOT NULL
+              AND p.provider = ANY(%s)
+            ORDER BY p.created_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT %s
+            """,
+            (list(providers), batch_size),
+        )
+        rows = cur.fetchall()
+
+    payments: List[Payment] = []
+    for row in rows:
+        payments.append(
+            Payment(
+                id=row["id"],
+                status=row["status"],
+                provider=row["provider"],
+                token=row["token"],
+                created_at=row["created_at"],
+                amount_minor=row["amount_minor"],
+                provider_metadata=row.get("provider_metadata"),
+                context=row.get("context"),
+                product_id=row.get("product_id"),
+                authorization_code=row.get("authorization_code"),
+                status_reason=row.get("status_reason"),
+                attempts=row.get("attempts", 0),
+            )
+        )
+    return payments
+
+
+def record_status_check(
+    conn,
+    *,
+    payment_id: int,
+    provider: str,
+    success: bool,
+    provider_status: str | None,
+    mapped_status: str | None,
+    response_code: int | None,
+    raw_payload: dict | None,
+    error_message: str | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO payments.status_check (
+                payment_id,
+                provider,
+                success,
+                provider_status,
+                mapped_status,
+                response_code,
+                raw_payload,
+                error_message,
+                requested_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, NOW())
+            """,
+            (
+                payment_id,
+                provider,
+                success,
+                provider_status,
+                mapped_status,
+                response_code,
+                psycopg2.extras.Json(raw_payload) if raw_payload is not None else None,
+                error_message,
+            ),
+        )
+
+
+def record_provider_event(
+    conn,
+    *,
+    payment_id: int,
+    provider: str,
+    request_url: str,
+    request_headers: dict,
+    request_body: dict | None,
+    response_status: int | None,
+    response_headers: dict | None,
+    response_body: dict | None,
+    error_message: str | None,
+    latency_ms: int | None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO payments.provider_event_log (
+                payment_id,
+                provider,
+                request_url,
+                request_headers,
+                request_body,
+                response_status,
+                response_headers,
+                response_body,
+                error_message,
+                latency_ms
+            )
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s::jsonb, %s::jsonb, %s, %s)
+            """,
+            (
+                payment_id,
+                provider,
+                request_url,
+                psycopg2.extras.Json(request_headers),
+                psycopg2.extras.Json(request_body) if request_body is not None else None,
+                response_status,
+                psycopg2.extras.Json(response_headers) if response_headers is not None else None,
+                psycopg2.extras.Json(response_body) if response_body is not None else None,
+                error_message,
+                latency_ms,
+            ),
+        )
+
+
+def update_payment_status(
+    conn,
+    *,
+    payment_id: int,
+    new_status: str,
+    status_reason: str | None,
+) -> None:
+    timestamp_field: str | None = None
+    if new_status == "AUTHORIZED":
+        timestamp_field = "first_authorized_at"
+    elif new_status == "FAILED":
+        timestamp_field = "failed_at"
+    elif new_status == "CANCELED":
+        timestamp_field = "canceled_at"
+    elif new_status == "REFUNDED":
+        timestamp_field = "refunded_at"
+    elif new_status == "ABANDONED":
+        timestamp_field = "abandoned_at"
+
+    set_clauses = ["status = %s", "updated_at = NOW()"]
+    params: List[object] = [new_status]
+    if status_reason is not None:
+        set_clauses.append("status_reason = %s")
+        params.append(status_reason)
+    if timestamp_field is not None:
+        set_clauses.append(f"{timestamp_field} = COALESCE({timestamp_field}, NOW())")
+
+    params.append(payment_id)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE payments.payment
+            SET {', '.join(set_clauses)}
+            WHERE id = %s
+            """,
+            params,
+        )
+
+
+def mark_attempts_exhausted(conn, *, payment_id: int) -> None:
+    update_payment_status(
+        conn,
+        payment_id=payment_id,
+        new_status="FAILED",
+        status_reason="reconcile attempts exhausted",
+    )
+
+
+def find_abandoned_payments(
+    conn,
+    *,
+    cutoff: datetime,
+    limit: int = 100,
+) -> List[Payment]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT
+                p.id,
+                p.status,
+                p.provider,
+                p.token,
+                p.created_at,
+                p.amount_minor,
+                p.provider_metadata,
+                p.context,
+                p.product_id,
+                p.authorization_code,
+                p.status_reason,
+                0 AS attempts
+            FROM payments.payment AS p
+            WHERE p.status = 'PENDING'
+              AND p.created_at <= %s
+            ORDER BY p.created_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT %s
+            """,
+            (cutoff, limit),
+        )
+        rows = cur.fetchall()
+
+    return [
+        Payment(
+            id=row["id"],
+            status=row["status"],
+            provider=row["provider"],
+            token=row["token"],
+            created_at=row["created_at"],
+            amount_minor=row["amount_minor"],
+            provider_metadata=row.get("provider_metadata"),
+            context=row.get("context"),
+            product_id=row.get("product_id"),
+            authorization_code=row.get("authorization_code"),
+            status_reason=row.get("status_reason"),
+            attempts=row.get("attempts", 0),
+        )
+        for row in rows
+    ]
+
+
+def log_service_runtime_event(
+    conn,
+    *,
+    event_type: str,
+    payload: dict | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO payments.service_runtime_log (
+                event_type,
+                payload
+            ) VALUES (%s, %s::jsonb)
+            """,
+            (
+                event_type,
+                psycopg2.extras.Json(payload) if payload is not None else None,
+            ),
+        )

--- a/src/services/crm_payloads.py
+++ b/src/services/crm_payloads.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..repositories.payments_repo import Payment
+
+
+def _extract_from_dict(data: Any, *keys: str) -> Any:
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def build_payload(payment: Payment, operation: str) -> Dict[str, Any]:
+    context = payment.context or {}
+    provider_metadata = payment.provider_metadata or {}
+
+    rut = _extract_from_dict(context, "customer_rut") or _extract_from_dict(provider_metadata, "rut")
+    name = (
+        _extract_from_dict(context, "customer_name")
+        or _extract_from_dict(provider_metadata, "name")
+        or "Pago Ninja"
+    )
+    transaction_id = payment.authorization_code or payment.token
+    amount_str = str(payment.amount_minor)
+    product_id = payment.product_id if isinstance(payment.product_id, int) else None
+
+    payload: Dict[str, Any] = {
+        "rutDepositante": rut,
+        "nombreDepositante": name,
+        "paymentMethod": payment.provider,
+        "transactionId": transaction_id,
+        "monto": amount_str,
+        "listContrato": [product_id] if product_id is not None else [],
+        "listCuota": None,
+        "operation": operation,
+        "paymentId": payment.id,
+    }
+    return payload

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _csv_to_int_list(value: str | List[int] | None, *, default: List[int]) -> List[int]:
+    if value is None:
+        return list(default)
+    if isinstance(value, list):
+        return [int(v) for v in value]
+    return [int(item.strip()) for item in value.split(",") if item.strip()]
+
+
+def _csv_to_str_list(value: str | List[str] | None, *, default: List[str]) -> List[str]:
+    if value is None:
+        return list(default)
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=(".env",), env_file_encoding="utf-8", extra="ignore")
+
+    app_name: str = Field(default="ninja-payments-reconciler", alias="APP_NAME")
+    database_dsn: str = Field(default="postgresql://localhost/payments", alias="DATABASE_DSN")
+
+    reconcile_enabled: bool = Field(default=True, alias="RECONCILE_ENABLED")
+    reconcile_interval_seconds: int = Field(default=15, alias="RECONCILE_INTERVAL_SECONDS")
+    reconcile_batch_size: int = Field(default=100, alias="RECONCILE_BATCH_SIZE")
+    reconcile_attempt_offsets_raw: str | List[int] | None = Field(
+        default=None, alias="RECONCILE_ATTEMPT_OFFSETS"
+    )
+    reconcile_polling_providers_raw: str | List[str] | None = Field(
+        default=None, alias="RECONCILE_POLLING_PROVIDERS"
+    )
+    abandoned_timeout_minutes: int = Field(default=60, alias="ABANDONED_TIMEOUT_MINUTES")
+
+    crm_enabled: bool = Field(default=True, alias="CRM_ENABLED")
+    crm_base_url: str = Field(
+        default="http://emprende-crm-prod-b0043c05a756b148.elb.us-east-1.amazonaws.com:8980/unify/inyeccion/contrato/v2",
+        alias="CRM_BASE_URL",
+    )
+    crm_pagar_path: str = Field(default="/pagar", alias="CRM_PAGAR_PATH")
+    crm_auth_bearer: str | None = Field(default=None, alias="CRM_AUTH_BEARER")
+    crm_timeout_seconds: int = Field(default=10, alias="CRM_TIMEOUT_SECONDS")
+    crm_retry_backoff_raw: str | List[int] | None = Field(
+        default=None, alias="CRM_RETRY_BACKOFF"
+    )
+    crm_log_requests: bool = Field(default=True, alias="CRM_LOG_REQUESTS")
+
+    heartbeat_interval_seconds: int = Field(default=60, alias="HEARTBEAT_INTERVAL_SECONDS")
+
+    @property
+    def reconcile_attempt_offsets(self) -> List[int]:
+        return _csv_to_int_list(
+            self.reconcile_attempt_offsets_raw, default=[60, 180, 900, 1800]
+        )
+
+    @property
+    def reconcile_polling_providers(self) -> List[str]:
+        return _csv_to_str_list(
+            self.reconcile_polling_providers_raw, default=["webpay", "stripe", "paypal"]
+        )
+
+    @property
+    def crm_retry_backoff(self) -> List[int]:
+        return _csv_to_int_list(self.crm_retry_backoff_raw, default=[60, 300, 1800])
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()


### PR DESCRIPTION
## Summary
- scaffold FastAPI service that starts PSP reconciliation and CRM sender loops on startup
- add database repositories, CRM payload builder, and polling workflows that follow retry and abandonment rules
- provide provider and CRM clients plus project dependencies for standalone deployment

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68df267bb7a8832fa2c31a4b5bfc40a5